### PR TITLE
Track tutorial scroll progress

### DIFF
--- a/docs/source/_static/js/init.js
+++ b/docs/source/_static/js/init.js
@@ -6,15 +6,18 @@ document.head.appendChild(script);
 
 // Track scrolling to h2 sections by id
 (function () {
+  var sentIds = [];
+
   const observerCallback = (entries, observer, h2) => {
     entries.forEach((entry, i) => {
       if (entry.isIntersecting) {
         // Get parent <section> of the h2, which has an id we can use to track
         var id = h2.closest("section").getAttribute("id");
-        if (id && gtag) {
+        if (id && gtag && !sentIds.includes(id)) {
           gtag("event", "doc_section_view", {
-            "doc_section_view_id": id
+            doc_section_view_id: id,
           });
+          sentIds.push(id);
         }
       }
     });

--- a/docs/source/_static/js/init.js
+++ b/docs/source/_static/js/init.js
@@ -1,5 +1,36 @@
 // Add cookieyes script
-var script = document.createElement('script');
-script.id = "cookieyes"
+var script = document.createElement("script");
+script.id = "cookieyes";
 script.src = "https://cdn-cookieyes.com/client_data/58bb4c6a9878d62a6e5f8065/script.js";
 document.head.appendChild(script);
+
+// Track scrolling to h2 sections by id
+(function () {
+  const observerCallback = (entries, observer, h2) => {
+    entries.forEach((entry, i) => {
+      if (entry.isIntersecting) {
+        // Get parent <section> of the h2, which has an id we can use to track
+        var id = h2.closest("section").getAttribute("id");
+        if (id && gtag) {
+          console.log(id);
+          gtag("event", "docs_section_view", {
+            "section": id
+          });
+        }
+      }
+    });
+  };
+
+  var article = document.querySelector("div[role=main]");
+  article.querySelectorAll("h2").forEach((h2) => {
+    if (h2) {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          observerCallback(entries, observer, h2);
+        },
+        { threshold: 1 }
+      );
+      observer.observe(h2);
+    }
+  });
+})();

--- a/docs/source/_static/js/init.js
+++ b/docs/source/_static/js/init.js
@@ -12,7 +12,6 @@ document.head.appendChild(script);
         // Get parent <section> of the h2, which has an id we can use to track
         var id = h2.closest("section").getAttribute("id");
         if (id && gtag) {
-          console.log(id);
           gtag("event", "docs_section_view", {
             "section": id
           });

--- a/docs/source/_static/js/init.js
+++ b/docs/source/_static/js/init.js
@@ -12,8 +12,8 @@ document.head.appendChild(script);
         // Get parent <section> of the h2, which has an id we can use to track
         var id = h2.closest("section").getAttribute("id");
         if (id && gtag) {
-          gtag("event", "docs_section_view", {
-            "section": id
+          gtag("event", "doc_section_view", {
+            "doc_section_view_id": id
           });
         }
       }


### PR DESCRIPTION
This sends GA4 events as the user scrolls through the tutorial, so we can see if they drop off in a particular place.